### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.2...v0.0.3) - 2024-04-03
+
+### Added
+- use `--bump` for version update
+- add publish command
+- add `regenerate_changelogs` command
+
+### Other
+- improve `regenerate_changelogs`
+
 ## [0.0.2](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.1...v0.0.2) - 2024-04-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-release-oxc"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Oxc release management"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.2 -> 0.0.3 (⚠️ API breaking changes)

### ⚠️ `cargo-release-oxc` breaking changes

```
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field PublishOptions.path in /tmp/.tmpZHNytC/cargo-release-oxc/src/publish.rs:17
  field PublishOptions.upload in /tmp/.tmpZHNytC/cargo-release-oxc/src/publish.rs:21

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_variant_added.ron

Failed in:
  variant ReleaseCommand:RegenerateChangelogs in /tmp/.tmpZHNytC/cargo-release-oxc/src/lib.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.3](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.2...v0.0.3) - 2024-04-03

### Added
- use `--bump` for version update
- add publish command
- add `regenerate_changelogs` command

### Other
- improve `regenerate_changelogs`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).