### PR TITLE
chore: release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.5...v0.0.6) - 2024-04-08
+
+### Added
+- run `cargo check` when Cargo.toml is update
+
 ## [0.0.5](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.4...v0.0.5) - 2024-04-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-release-oxc"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 description = "Oxc release management"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.5 -> 0.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.6](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.5...v0.0.6) - 2024-04-08

### Added
- run `cargo check` when Cargo.toml is update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).