### PR TITLE
chore: release v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.7...v0.0.8) - 2024-05-20
+
+### Fixed
+- use rustls
+
+### Other
+- allow branch `renovate/**`
+- *(deps)* lock file maintenance rust crates ([#17](https://github.com/oxc-project/cargo-release-oxc/pull/17))
+- release ([#9](https://github.com/oxc-project/cargo-release-oxc/pull/9))
+
 ## [0.0.7](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.6...v0.0.7) - 2024-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.7"
+version     = "0.0.8"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.7 -> 0.0.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.8](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.7...v0.0.8) - 2024-05-20

### Fixed
- use rustls

### Other
- allow branch `renovate/**`
- *(deps)* lock file maintenance rust crates ([#17](https://github.com/oxc-project/cargo-release-oxc/pull/17))
- release ([#9](https://github.com/oxc-project/cargo-release-oxc/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).