### PR TITLE
chore: release v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.9...v0.0.10) - 2024-06-04
+
+### Added
+- check git status before running anything
+- add `--release name`
+- update package.json versions
+- add configuration
+- calculate next version from changelog
+- `update` print version
+- remove cargo check in update command
+- customize tag prefix
+
+### Other
+- add release manual trigger
+- remove `semver`
+- unwrap parent
+- refactor out versioning crates
+- alias r in justfile
+
 ## [0.0.9](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.8...v0.0.9) - 2024-06-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.9"
+version     = "0.0.10"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.9 -> 0.0.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.10](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.9...v0.0.10) - 2024-06-04

### Added
- check git status before running anything
- add `--release name`
- update package.json versions
- add configuration
- calculate next version from changelog
- `update` print version
- remove cargo check in update command
- customize tag prefix

### Other
- add release manual trigger
- remove `semver`
- unwrap parent
- refactor out versioning crates
- alias r in justfile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).