### PR TITLE
chore: release v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.12...v0.0.13) - 2024-06-05
+
+### Added
+- support versioning non-workspace cargo toml
+
+### Other
+- update
+- update git cliff
+- add rust cache
+
 ## [0.0.12](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.11...v0.0.12) - 2024-06-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.12"
+version     = "0.0.13"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.12 -> 0.0.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.13](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.12...v0.0.13) - 2024-06-05

### Added
- support versioning non-workspace cargo toml

### Other
- update
- update git cliff
- add rust cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).