### PR TITLE
chore: release v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.13...v0.0.14) - 2024-06-06
+
+### Added
+- remove change log header from the printed out version
+
 ## [0.0.13](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.12...v0.0.13) - 2024-06-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.13"
+version     = "0.0.14"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.13 -> 0.0.14

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.14](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.13...v0.0.14) - 2024-06-06

### Added
- remove change log header from the printed out version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).