### PR TITLE
chore: release v0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.14...v0.0.15) - 2024-06-07
+
+### Added
+- add `changelog` command
+
+### Other
+- clean up some code
+- unify options
+
 ## [0.0.14](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.13...v0.0.14) - 2024-06-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.14"
+version     = "0.0.15"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.14 -> 0.0.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.15](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.14...v0.0.15) - 2024-06-07

### Added
- add `changelog` command

### Other
- clean up some code
- unify options
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).