### PR TITLE
chore: release v0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.16](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.15...v0.0.16) - 2024-06-14
+
+### Other
+- *(deps)* update dependency rust to v1.79.0 ([#34](https://github.com/oxc-project/cargo-release-oxc/pull/34))
+- *(deps)* update rust crates
+
 ## [0.0.15](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.14...v0.0.15) - 2024-06-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.15"
+version     = "0.0.16"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.15 -> 0.0.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.16](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.15...v0.0.16) - 2024-06-14

### Other
- *(deps)* update dependency rust to v1.79.0 ([#34](https://github.com/oxc-project/cargo-release-oxc/pull/34))
- *(deps)* update rust crates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).