### PR TITLE
chore: release v0.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.17](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.16...v0.0.17) - 2024-06-14
+
+### Other
+- remove cargo check from publish
+- add dry-run
+- print to file instead of to terminal
+
 ## [0.0.16](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.15...v0.0.16) - 2024-06-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.16"
+version     = "0.0.17"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.16 -> 0.0.17

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.17](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.16...v0.0.17) - 2024-06-14

### Other
- remove cargo check from publish
- add dry-run
- print to file instead of to terminal
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).