### PR TITLE
chore: release v0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.18](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.17...v0.0.18) - 2024-06-19
+
+### Other
+- skip not found packages
+
 ## [0.0.17](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.16...v0.0.17) - 2024-06-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.17"
+version     = "0.0.18"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.17 -> 0.0.18

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.18](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.17...v0.0.18) - 2024-06-19

### Other
- skip not found packages
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).