### PR TITLE
chore: release v0.0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.23](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.22...v0.0.23) - 2024-08-29
+
+### Added
+- only matching scopes can participate in braking change detection.
+
+### Other
+- bump rust
+- bump deps
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- trigger release-binaries manually
+
 ## [0.0.22](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.21...v0.0.22) - 2024-08-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.22"
+version     = "0.0.23"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.22 -> 0.0.23

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.23](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.22...v0.0.23) - 2024-08-29

### Added
- only matching scopes can participate in braking change detection.

### Other
- bump rust
- bump deps
- *(deps)* update rust crates
- *(deps)* update rust crates
- trigger release-binaries manually
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).