### PR TITLE
chore: release v0.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.24](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.23...v0.0.24) - 2024-10-09
+
+### Other
+
+- *(deps)* update rust crates ([#51](https://github.com/oxc-project/cargo-release-oxc/pull/51))
+- *(deps)* update rust crates ([#50](https://github.com/oxc-project/cargo-release-oxc/pull/50))
+- *(renovate)* bump
+- *(deps)* update dependency rust to v1.81.0 ([#48](https://github.com/oxc-project/cargo-release-oxc/pull/48))
+
 ## [0.0.23](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.22...v0.0.23) - 2024-08-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.23"
+version     = "0.0.24"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.23 -> 0.0.24 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.24](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.23...v0.0.24) - 2024-10-09

### Other

- *(deps)* update rust crates ([#51](https://github.com/oxc-project/cargo-release-oxc/pull/51))
- *(deps)* update rust crates ([#50](https://github.com/oxc-project/cargo-release-oxc/pull/50))
- *(renovate)* bump
- *(deps)* update dependency rust to v1.81.0 ([#48](https://github.com/oxc-project/cargo-release-oxc/pull/48))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).