### PR TITLE
chore: release v0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.25](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.24...v0.0.25) - 2024-11-04
+
+### Other
+
+- add newline to end of package.json
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- *(deps)* update dependency rust to v1.82.0 ([#52](https://github.com/oxc-project/cargo-release-oxc/pull/52))
+
 ## [0.0.24](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.23...v0.0.24) - 2024-10-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.24"
+version     = "0.0.25"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-release-oxc`: 0.0.24 -> 0.0.25 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.25](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.24...v0.0.25) - 2024-11-04

### Other

- add newline to end of package.json
- *(deps)* update rust crates
- *(deps)* update rust crates
- *(deps)* update rust crates
- *(deps)* update dependency rust to v1.82.0 ([#52](https://github.com/oxc-project/cargo-release-oxc/pull/52))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).