### PR TITLE
chore: release v0.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.26](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.25...v0.0.26) - 2025-02-09
+
+### Other
+
+- *(deps)* update rust crate toml to 0.8.20 (#63)
+- *(deps)* update rust crates (#62)
+- *(deps)* update dependency rust to v1.84.1 (#61)
+- *(deps)* update rust crates (#60)
+- *(deps)* update rust crate serde_json to 1.0.137 (#59)
+- *(deps)* update rust crate serde_json to 1.0.136 (#58)
+- *(deps)* update rust crate serde_json to 1.0.135 (#57)
+- *(deps)* update dependency rust to v1.84.0 (#56)
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- *(deps)* update rust crate serde to 1.0.216
+- *(deps)* update rust crates
+- *(deps)* update dependency rust to v1.83.0 (#55)
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- *(deps)* update rust crate anyhow to 1.0.93
+
 ## [0.0.25](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.24...v0.0.25) - 2024-11-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.25"
+version     = "0.0.26"
 edition     = "2021"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-release-oxc`: 0.0.25 -> 0.0.26 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.26](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.25...v0.0.26) - 2025-02-09

### Other

- *(deps)* update rust crate toml to 0.8.20 (#63)
- *(deps)* update rust crates (#62)
- *(deps)* update dependency rust to v1.84.1 (#61)
- *(deps)* update rust crates (#60)
- *(deps)* update rust crate serde_json to 1.0.137 (#59)
- *(deps)* update rust crate serde_json to 1.0.136 (#58)
- *(deps)* update rust crate serde_json to 1.0.135 (#57)
- *(deps)* update dependency rust to v1.84.0 (#56)
- *(deps)* update rust crates
- *(deps)* update rust crates
- *(deps)* update rust crate serde to 1.0.216
- *(deps)* update rust crates
- *(deps)* update dependency rust to v1.83.0 (#55)
- *(deps)* update rust crates
- *(deps)* update rust crates
- *(deps)* update rust crate anyhow to 1.0.93
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).