### PR TITLE
chore: release v0.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.27](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.26...v0.0.27) - 2025-02-22
+
+### Other
+
+- Rust Edition 2024
+- *(deps)* update dependency rust to v1.85.0 (#66)
+- *(deps)* pin dependencies (#65)
+- pinGitHubActionDigestsToSemver
+- use macos-13
+
 ## [0.0.26](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.25...v0.0.26) - 2025-02-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.26"
+version     = "0.0.27"
 edition     = "2024"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-release-oxc`: 0.0.26 -> 0.0.27 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.27](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.26...v0.0.27) - 2025-02-22

### Other

- Rust Edition 2024
- *(deps)* update dependency rust to v1.85.0 (#66)
- *(deps)* pin dependencies (#65)
- pinGitHubActionDigestsToSemver
- use macos-13
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).