### PR TITLE
chore: release v0.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.28](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.27...v0.0.28) - 2025-03-09
+
+### Other
+
+- *(deps)* update marcoieni/release-plz-action digest to 476794e ([#74](https://github.com/oxc-project/cargo-release-oxc/pull/74))
+- use OXC_BOT_PAT
+- *(deps)* lock file maintenance rust crates ([#72](https://github.com/oxc-project/cargo-release-oxc/pull/72))
+- *(deps)* update marcoieni/release-plz-action digest to 7049379 ([#71](https://github.com/oxc-project/cargo-release-oxc/pull/71))
+- *(deps)* lock file maintenance ([#69](https://github.com/oxc-project/cargo-release-oxc/pull/69))
+- *(deps)* update github-actions ([#68](https://github.com/oxc-project/cargo-release-oxc/pull/68))
+
 ## [0.0.27](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.26...v0.0.27) - 2025-02-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-release-oxc"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "cargo-release-oxc"
-version     = "0.0.27"
+version     = "0.0.28"
 edition     = "2024"
 description = "Oxc release management"
 authors     = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-release-oxc`: 0.0.27 -> 0.0.28 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.28](https://github.com/oxc-project/cargo-release-oxc/compare/v0.0.27...v0.0.28) - 2025-03-09

### Other

- *(deps)* update marcoieni/release-plz-action digest to 476794e ([#74](https://github.com/oxc-project/cargo-release-oxc/pull/74))
- use OXC_BOT_PAT
- *(deps)* lock file maintenance rust crates ([#72](https://github.com/oxc-project/cargo-release-oxc/pull/72))
- *(deps)* update marcoieni/release-plz-action digest to 7049379 ([#71](https://github.com/oxc-project/cargo-release-oxc/pull/71))
- *(deps)* lock file maintenance ([#69](https://github.com/oxc-project/cargo-release-oxc/pull/69))
- *(deps)* update github-actions ([#68](https://github.com/oxc-project/cargo-release-oxc/pull/68))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).