### PR TITLE
ci: replace OXC_BOT_PAT with GitHub App tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: oxc-project/release-plz@e2b12f55ad64a22af8e93634b94439c42913afca # v1.0.6
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: app-token
         with:
-          PAT: ${{ secrets.OXC_BOT_PAT }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: oxc-project/release-plz@44b98e8dda1a7783d4ec2ef66e2f37a3e8c1c759 # v1.0.4
+        with:
+          PAT: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- replace `OXC_BOT_PAT` workflow usage with `actions/create-github-app-token`
- use `APP_ID` and `APP_PRIVATE_KEY` to mint per-job GitHub App installation tokens
- keep existing workflow behavior for PR creation, release flows, comments, dispatches, and checkout-backed pushes
