### PR TITLE
chore(ci): use ubuntu-latest for security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: oxc-project/security-action@77e230508eccbb400b23746dab6c573a8ea7483e # v1.0.5


### PR DESCRIPTION
## Summary
- Switch `runs-on` from `ubuntu-slim` to `ubuntu-latest` in `.github/workflows/security.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)