### PR TITLE
feat(update): opt-in changelog generation via --changelog

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,10 @@ pub struct Options {
     #[bpaf(switch, fallback(false))]
     pub dry_run: bool,
 
+    /// For `update`: also write CHANGELOG.md files alongside the version bump.
+    #[bpaf(switch, fallback(false))]
+    pub changelog: bool,
+
     /// Optional path to directory, defaults to current working directory.
     #[bpaf(positional("PATH"), fallback_with(crate::current_dir))]
     pub path: PathBuf,
@@ -31,7 +35,7 @@ pub struct Options {
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(options("release-oxc"))]
 pub enum ReleaseCommand {
-    /// Generate CHANGELOG.md and bump versions for all published packages.
+    /// Bump versions for all published packages. Pass --changelog to also write CHANGELOG.md.
     #[bpaf(command)]
     Update(#[bpaf(external(options))] Options),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn update(options: &Options) -> Result<()> {
     let cwd = &options.path;
     check_git_clean(cwd)?;
     for release_name in &options.release {
-        Update::new(cwd, release_name)?.run()?;
+        Update::new(cwd, release_name)?.run(options)?;
     }
     Ok(())
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,7 +10,10 @@ use git_cliff_core::{
     repo::Repository,
 };
 
-use crate::config::{ReleaseConfig, ReleaseSet, VersionedPackage};
+use crate::{
+    Options,
+    config::{ReleaseConfig, ReleaseSet, VersionedPackage},
+};
 
 const CHANGELOG_NAME: &str = "CHANGELOG.md";
 
@@ -69,10 +72,16 @@ impl Update {
         Ok(Self { cwd, release_set, git_cliff_repo, git_cliff_config, tags, current_version })
     }
 
-    pub fn run(&self) -> Result<()> {
-        let next_version = self.changelog_for_release()?;
-        for package in self.release_set.versioned_packages() {
-            self.generate_changelog_for_package(&package, &next_version)?;
+    pub fn run(&self, options: &Options) -> Result<()> {
+        let next_version = self.calculate_next_version()?;
+        if options.changelog {
+            self.print_changelog_for_release(&next_version)?;
+        }
+        self.write_version_file(&next_version)?;
+        if options.changelog {
+            for package in self.release_set.versioned_packages() {
+                self.generate_changelog_for_package(&package, &next_version)?;
+            }
         }
         self.release_set.update_version(&next_version)?;
         Ok(())
@@ -81,10 +90,15 @@ impl Update {
     pub fn changelog_for_release(&self) -> Result<String> {
         let next_version = self.calculate_next_version()?;
         self.print_changelog_for_release(&next_version)?;
+        self.write_version_file(&next_version)?;
+        Ok(next_version)
+    }
+
+    fn write_version_file(&self, next_version: &str) -> Result<()> {
         let var = format!("{}_VERSION", self.release_set.name.to_uppercase());
         let file = Path::new("./target").join(var);
-        fs::write(file, &next_version)?;
-        Ok(next_version)
+        fs::write(file, next_version)?;
+        Ok(())
     }
 
     fn calculate_next_version(&self) -> Result<String> {


### PR DESCRIPTION
## Summary

\`update\` used to always do three things at once: compute the next version, write the changelog files (\`./target/<NAME>_CHANGELOG\` plus per-package \`CHANGELOG.md\`), and bump versions in Cargo.toml. Some release flows want the version bump on its own — for example, a workflow that takes a fixed version input and aligns crate versions with npm package versions, without producing a separate Rust-side changelog.

Add \`--changelog\` to opt in to the previous behavior. Default is now bump-only:

- Compute the next version (still uses git-cliff over commits since the latest \`<release>_v*\` tag).
- Write \`./target/<NAME>_VERSION\`.
- Update versions in Cargo.toml.

With \`--changelog\` the release summary and per-package CHANGELOG.md writes happen on top.

## Breaking change

Existing consumers that relied on \`cargo release-oxc update\` writing CHANGELOG.md must add \`--changelog\` to preserve current behavior. (oxc itself uses this — its \`prepare_release_crates.yml\` will need the flag added.)

## Notes

- \`changelog\` subcommand is unchanged — it still writes the release summary.
- \`regenerate-changelogs\` and \`publish\` are untouched.