### PR TITLE
feat(publish): clearer error reporting and progress output

### DIFF
--- a/src/cargo_command.rs
+++ b/src/cargo_command.rs
@@ -15,6 +15,10 @@ pub struct CmdOutput {
     pub stderr: String,
 }
 
+fn exit_code(status: ExitStatus) -> String {
+    status.code().map_or_else(|| "?".to_string(), |c| c.to_string())
+}
+
 pub struct CargoCommand {
     current_dir: PathBuf,
 }
@@ -27,7 +31,12 @@ impl CargoCommand {
     pub fn check(&self, package_name: &str) -> Result<()> {
         let output = self.run(&["check", "-p", package_name])?;
         if !output.status.success() {
-            anyhow::bail!("failed to check {}: {}", package_name, output.stderr);
+            anyhow::bail!(
+                "`cargo check -p {}` failed with exit code {}:\n{}",
+                package_name,
+                exit_code(output.status),
+                output.stderr,
+            );
         }
         Ok(())
     }
@@ -38,11 +47,14 @@ impl CargoCommand {
             args.push("--dry-run");
         }
         let output = self.run(&args)?;
-        if !output.status.success()
-            || !output.stderr.contains("Uploading")
-            || output.stderr.contains("error:")
-        {
-            anyhow::bail!("failed to publish {}: {}", package_name, output.stderr);
+        if !output.status.success() {
+            anyhow::bail!(
+                "`cargo publish -p {}{}` failed with exit code {}:\n{}",
+                package_name,
+                if dry_run { " --dry-run" } else { "" },
+                exit_code(output.status),
+                output.stderr,
+            );
         }
         Ok(())
     }

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -48,23 +48,38 @@ impl Publish {
         let root_version = root_package.version.to_string();
 
         let packages = release_order::release_order(&packages)?;
-        let packages = packages.into_iter().map(|package| &package.name).collect::<Vec<_>>();
+        let packages: Vec<&str> =
+            packages.into_iter().map(|package| package.name.as_str()).collect();
 
-        eprintln!("Publishing packages:");
+        let total = packages.len();
+        eprintln!("Publishing {total} package(s):");
         for package in &packages {
-            eprintln!("{}", package.as_str());
+            eprintln!("  - {package}");
         }
-        for package in &packages {
+
+        let mut published: Vec<&str> = vec![];
+        let mut skipped: Vec<&str> = vec![];
+        for (idx, package) in packages.iter().enumerate() {
+            eprintln!("\n[{}/{total}] {package}", idx + 1);
+            let summary = || publish_failure_summary(package, idx, &packages, &published, &skipped);
             if self.dry_run {
                 // check each crate individually to prevent feature unification.
-                self.cargo.check(package)?;
+                self.cargo.check(package).with_context(summary)?;
             }
-            if self.skip_published(package, &root_version) {
+            if self.skip_published(package, &root_version)? {
+                skipped.push(package);
                 continue;
             }
-            self.cargo.publish(package, self.dry_run)?;
-            eprintln!("Published: {}", package.as_str());
+            self.cargo.publish(package, self.dry_run).with_context(summary)?;
+            published.push(package);
+            eprintln!("  ✓ published");
         }
+
+        eprintln!(
+            "\nDone. {} published, {} skipped (already on registry), {total} total.",
+            published.len(),
+            skipped.len(),
+        );
 
         let release_name = &self.release_set.name;
         let version = format!("{release_name}_v{root_version}");
@@ -74,23 +89,57 @@ impl Publish {
         Ok(())
     }
 
-    fn skip_published(&self, package: &str, root_version: &str) -> bool {
-        let Ok(krate) = self.client.get_crate(package) else {
-            eprintln!("Cannot get {package}");
-            return false;
-        };
-        let versions = krate.versions.into_iter().map(|version| version.num).collect::<Vec<_>>();
-        let is_already_published = versions.iter().any(|v| v == root_version);
-        if is_already_published {
-            eprintln!("Already published {package} {root_version}");
+    fn skip_published(&self, package: &str, root_version: &str) -> Result<bool> {
+        match self.client.get_crate(package) {
+            Ok(krate) => {
+                let is_already_published =
+                    krate.versions.iter().any(|version| version.num == root_version);
+                if is_already_published {
+                    eprintln!("  · already on crates.io @ {root_version}, skipping");
+                }
+                Ok(is_already_published)
+            }
+            Err(crates_io_api::Error::NotFound(_)) => {
+                // Brand-new crate, never published; not an error.
+                eprintln!("  · not yet on crates.io (new crate)");
+                Ok(false)
+            }
+            Err(err) => Err(err).with_context(|| {
+                format!(
+                    "failed to query crates.io for `{package}` — \
+                     cannot determine whether to publish or skip"
+                )
+            }),
         }
-        is_already_published
     }
 
     fn get_packages(&self) -> Vec<&Package> {
         // `publish.is_none()` means `publish = true`.
         self.metadata.workspace_packages().into_iter().filter(|p| p.publish.is_none()).collect()
     }
+}
+
+fn publish_failure_summary(
+    failed: &str,
+    failed_idx: usize,
+    all: &[&str],
+    published: &[&str],
+    skipped: &[&str],
+) -> String {
+    use std::fmt::Write;
+    let remaining = &all[failed_idx + 1..];
+    let mut out =
+        format!("publish failed at `{failed}` ({}/{} in order)", failed_idx + 1, all.len());
+    if !published.is_empty() {
+        write!(out, "\n  published before failure: {published:?}").unwrap();
+    }
+    if !skipped.is_empty() {
+        write!(out, "\n  skipped (already on registry): {skipped:?}").unwrap();
+    }
+    if !remaining.is_empty() {
+        write!(out, "\n  not attempted: {remaining:?}").unwrap();
+    }
+    out
 }
 
 mod release_order {


### PR DESCRIPTION
## Summary

A user hit a partial-publish failure on a 30+ crate workspace where the publish loop bailed mid-way and they couldn't easily tell what state things were in. This PR makes failures self-documenting.

## Before

When something failed, you got just the underlying cargo error, with no context for which crate (out of how many) had failed, what had already been published, what was skipped, or what hadn't been attempted yet.

Additionally:
- The `stderr.contains(\"error:\")` check was silently broken — with `--color always` cargo emits `\\x1b[1m\\x1b[91merror\\x1b[0m:`, so the literal substring `error:` is never present. Real failures were still caught by the exit-status check, but the redundant check looked load-bearing.
- `stderr.contains(\"Uploading\")` was a language-fragile defensive check.
- `skip_published` swallowed every crates.io API error as \"not found\" and continued with the publish attempt — no way to distinguish a brand-new crate from a network blip or rate-limit.

## After

Per-crate progress as the loop runs:

```
Publishing 33 package(s):
  - rolldown_error
  - ...

[1/33] rolldown_error
  · already on crates.io @ 0.1.1, skipping
[2/33] rolldown_ecmascript
  · already on crates.io @ 0.1.1, skipping
...
[25/33] rolldown_fs_watcher
  · not yet on crates.io (new crate)
```

On failure, the error now carries the full diagnostic:

```
Error: publish failed at `rolldown_fs_watcher` (25/33 in order)
  skipped (already on registry): [\"rolldown_error\", \"rolldown_ecmascript\", ...]
  not attempted: [\"rolldown_dev\", \"rolldown_plugin_bundle_analyzer\", ...]

Caused by:
    `cargo publish -p rolldown_fs_watcher --dry-run` failed with exit code 101:
    error: 2 files in the working directory contain changes that were not yet committed into git:
    ...
```

On success, a tail summary: `Done. N published, M skipped, T total.`

## Changes

- Drop the brittle `stderr.contains(\"error:\")` and `stderr.contains(\"Uploading\")` checks in `CargoCommand::publish`. Rely on exit status (which is the actually-reliable signal) and put the exit code into the error message.
- `skip_published` returns `Result<bool>`. `crates_io_api::Error::NotFound` is handled explicitly as \"new crate, do publish\"; any other error propagates with context — no more silent swallowing of API failures.
- `Publish::run` tracks per-crate state, prints positional progress (`[N/total]`), and attaches a failure summary via `with_context` when any step fails. The underlying cargo error is preserved as the `Caused by:` chain.