### PR TITLE
feat(publish): pre-flight validate metadata before the publish loop

### DIFF
--- a/src/publish.rs
+++ b/src/publish.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use cargo_metadata::{Metadata, MetadataCommand, Package};
+use cargo_metadata::{DependencyKind, Metadata, MetadataCommand, Package};
 use crates_io_api::SyncClient;
 
 use crate::{
@@ -46,6 +46,8 @@ impl Publish {
         };
 
         let root_version = root_package.version.to_string();
+
+        validate_packages(&packages)?;
 
         let packages = release_order::release_order(&packages)?;
         let packages: Vec<&str> =
@@ -117,6 +119,51 @@ impl Publish {
         // `publish.is_none()` means `publish = true`.
         self.metadata.workspace_packages().into_iter().filter(|p| p.publish.is_none()).collect()
     }
+}
+
+/// Catch metadata issues that would fail at upload time before we burn
+/// minutes of publish-loop work to discover them one crate at a time.
+fn validate_packages(packages: &[&Package]) -> Result<()> {
+    let mut errors: Vec<String> = vec![];
+    for pkg in packages {
+        if pkg.description.as_deref().is_none_or(str::is_empty) {
+            errors.push(format!(
+                "`{}`: missing `description` field — crates.io requires it",
+                pkg.name,
+            ));
+        }
+        if pkg.license.is_none() && pkg.license_file.is_none() {
+            errors.push(format!(
+                "`{}`: missing `license` or `license-file` field — crates.io requires one",
+                pkg.name,
+            ));
+        }
+        for dep in &pkg.dependencies {
+            if dep.kind == DependencyKind::Development {
+                // Dev-deps are stripped at publish time; missing version is fine.
+                continue;
+            }
+            // `source` is `None` for path-only deps with no registry. A `req` of
+            // `*` means no version requirement was given, so cargo would refuse
+            // to verify the manifest at upload time.
+            if dep.source.is_none() && dep.req.to_string() == "*" {
+                errors.push(format!(
+                    "`{}`: dependency `{}` is path-only without a version requirement \
+                     — cargo refuses to publish (use a `version` or route through \
+                     `[workspace.dependencies]`)",
+                    pkg.name, dep.name,
+                ));
+            }
+        }
+    }
+    if errors.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "Pre-flight validation found {} issue(s):\n  - {}",
+        errors.len(),
+        errors.join("\n  - "),
+    );
 }
 
 fn publish_failure_summary(


### PR DESCRIPTION
## Summary

`Publish::run` now runs a metadata validation pass over every publishable workspace member before the first `cargo publish` is invoked. This catches the two issue classes that have historically broken release runs partway through, where each failure cost a full publish-loop cycle to discover and a follow-up PR + re-run to fix.

## What's checked

For each publishable workspace member:

1. **`description`** must be present and non-empty. crates.io rejects uploads without it (HTTP 400, \`missing or empty metadata fields: description\`).
2. **`license` or `license-file`** must be present. Also a crates.io upload requirement.
3. **Normal and build dependencies** must either have a version requirement or come from a registry (workspace deps qualify). A `path`-only dep with no version makes cargo refuse to verify the manifest at upload time with \`all dependencies must have a version requirement specified when publishing\`.

Dev-dependencies are skipped — cargo strips path-only dev-deps without versions automatically when packaging.

## Failure mode

All issues are collected and reported together. One dry-run surfaces every issue at once instead of fixing them one round-trip at a time:

```
Error: Pre-flight validation found 2 issue(s):
  - `rolldown_plugin_lazy_compilation`: missing `description` field — crates.io requires it
  - `rolldown_watcher`: dependency `rolldown` is path-only without a version requirement — cargo refuses to publish (use a `version` or route through `[workspace.dependencies]`)
```

## Cost

Pure metadata inspection on already-loaded `cargo_metadata` output. Runs in milliseconds. No subprocess, no network. Pure pre-flight gain.