### PR TITLE
fix(release-plz): skip release commits to prevent no-op follow-up PRs

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,3 +4,17 @@
 # to crates.io and pushes the tag. This avoids the immutable-release 422 that
 # blocks uploading assets after the release is published.
 git_release_enable = false
+
+[changelog]
+# Skip release-PR merge commits when regenerating the changelog so release-plz
+# doesn't open a no-op follow-up PR after each release. Defaults are
+# re-declared because commit_parsers replaces them rather than extending.
+commit_parsers = [
+  { message = "^chore: release", skip = true },
+  { message = "^feat",       group = "added" },
+  { message = "^changed",    group = "changed" },
+  { message = "^deprecated", group = "deprecated" },
+  { message = "^fix",        group = "fixed" },
+  { message = "^security",   group = "security" },
+  { message = "^.*",         group = "other" },
+]


### PR DESCRIPTION
## Summary

After each release PR merged, release-plz opened a second no-op release PR
with the same version — e.g. #245 immediately after #243 for v0.0.42, and
#241 after #238 for v0.0.41 (which we closed manually). v0.0.42 got merged
because the duplicate had the same title as the real release PR.

**Root cause.** release-plz runs its `update` phase before its `release/tag`
phase in the same job. After a release-PR merge, the new tag doesn't exist
yet, so release-plz regenerates the changelog from commits since the
previous tag — which now includes the `chore: release vX` merge commit
itself. The default catch-all parser (`^.*` → `other`) groups it under an
"Other" section, the committed CHANGELOG is missing that line, so
release-plz opens a follow-up PR to reconcile.

**Fix.** Add a `commit_parsers` skip rule for `^chore: release`. The
regenerated changelog then matches the committed one, and no follow-up PR
is opened. Because `commit_parsers` replaces the defaults instead of
extending them, the other default rules are re-declared verbatim.