### PR TITLE
chore: bump oxc-project/security-action to v1.0.7

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,4 +21,4 @@ jobs:
     name: Security Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: oxc-project/security-action@77e230508eccbb400b23746dab6c573a8ea7483e # v1.0.5
+      - uses: oxc-project/security-action@cba83d3159bd19731697875c03613fd0fe389f27 # v1.0.7


### PR DESCRIPTION
## Summary
- Bumps `oxc-project/security-action` from v1.0.5 to v1.0.7.
- v1.0.7 includes [oxc-project/security-action#19](https://github.com/oxc-project/security-action/pull/19), which adds `RUSTSEC-2025-0141` (bincode unmaintained) to the ignored advisories list.
- Fixes the failing Security Analysis check seen on #246.