### PR TITLE
Support subdirectory workspaces, renamed deps, and version.workspace

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -52,7 +52,9 @@ impl Update {
 
         let release_set = ReleaseConfig::new(&cwd)?.get_release(release_name)?;
 
-        let git_cliff_repo = Repository::init(cwd.clone())?;
+        // `discover` walks up to find the repository, so this also works when the
+        // workspace is a subdirectory of the git repo (not the repo root).
+        let git_cliff_repo = Repository::discover(cwd.clone())?;
         let git_cliff_config = Config::load(&cwd.join(DEFAULT_CONFIG))?;
         let tag_pattern = regex::Regex::new(&format!("^{release_name}_v[0-9]*"))
             .context("failed to make regex")?;

--- a/src/versioning/cargo.rs
+++ b/src/versioning/cargo.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use cargo_metadata::MetadataCommand;
-use toml_edit::{DocumentMut, Formatted, Value};
+use toml_edit::{DocumentMut, Formatted, Item, Value};
 
 use crate::config::VersionedPackage;
 
@@ -63,6 +63,9 @@ impl CargoToml {
     pub fn update_version(&self, version: &str) -> Result<()> {
         if self.is_workspace {
             let mut workspace_toml = CargoTomlFile::new(&self.path)?;
+            // Bump `[workspace.package].version` for members that inherit it via
+            // `version.workspace = true` (no-op if the workspace doesn't set one).
+            workspace_toml.set_workspace_package_version(version);
             for package in &self.packages {
                 workspace_toml.set_workspace_dependency_version(&package.name, version)?;
             }
@@ -104,28 +107,70 @@ impl CargoTomlFile {
         else {
             anyhow::bail!("`workspace.dependencies` field not found: {}", self.path.display());
         };
+        // Match the dependency by its key, or by its `package` field for a renamed
+        // dependency, e.g. `alias = { package = "crate_name", version = ".." }`.
+        let Some(key) = table
+            .iter()
+            .find(|(key, item)| {
+                *key == crate_name
+                    || item
+                        .as_inline_table()
+                        .and_then(|t| t.get("package"))
+                        .and_then(toml_edit::Value::as_str)
+                        == Some(crate_name)
+            })
+            .map(|(key, _)| key.to_string())
+        else {
+            anyhow::bail!("dependency `{}` not found: {}", crate_name, self.path.display());
+        };
         let Some(version_field) = table
-            .get_mut(crate_name)
+            .get_mut(&key)
             .and_then(|item| item.as_inline_table_mut())
             .and_then(|item| item.get_mut("version"))
         else {
-            anyhow::bail!("dependency `{}` not found: {}", crate_name, self.path.display());
+            anyhow::bail!("dependency `{}` has no `version`: {}", crate_name, self.path.display());
         };
         *version_field = Value::String(Formatted::new(version.to_string()));
         Ok(())
     }
 
+    /// Set `[workspace.package].version` if present; no-op otherwise.
+    fn set_workspace_package_version(&mut self, version: &str) {
+        if let Some(version_field) = self
+            .toml
+            .get_mut("workspace")
+            .and_then(|item| item.as_table_mut())
+            .and_then(|table| table.get_mut("package"))
+            .and_then(|item| item.as_table_mut())
+            .and_then(|table| table.get_mut("version"))
+            .and_then(|item| item.as_value_mut())
+        {
+            *version_field = Value::String(Formatted::new(version.to_string()));
+        }
+    }
+
     fn set_package_version(&mut self, version: &str) -> Result<()> {
-        let Some(version_field) = self
+        let Some(version_item) = self
             .toml
             .get_mut("package")
             .and_then(|item| item.as_table_mut())
             .and_then(|table| table.get_mut("version"))
-            .and_then(|item| item.as_value_mut())
         else {
             anyhow::bail!("No `package.version` field found: {}", self.path.display());
+        };
+        // `version.workspace = true` is inherited and bumped on the workspace instead.
+        if is_workspace_inherited(version_item) {
+            return Ok(());
+        }
+        let Some(version_field) = version_item.as_value_mut() else {
+            anyhow::bail!("`package.version` is not a string: {}", self.path.display());
         };
         *version_field = Value::String(Formatted::new(version.to_string()));
         Ok(())
     }
+}
+
+/// Whether a manifest field is inherited from the workspace (`<field>.workspace = true`).
+fn is_workspace_inherited(item: &Item) -> bool {
+    item.as_table_like().and_then(|t| t.get("workspace")).and_then(Item::as_bool) == Some(true)
 }


### PR DESCRIPTION
Generalizes `update` so it works on workspaces that aren't the plain "crates at the repo root, literal per-crate versions" shape. Motivated by [oxc-project/forked-react-compiler](https://github.com/oxc-project/forked-react-compiler), which vendors react's compiler into a `react-compiler/` subdirectory and publishes the crates under renamed package names while keeping the original import names.

### Changes

1. **Discover the git repo upward** (`update.rs`) — `Repository::init(cwd)` only opens a repo at the exact `cwd`, so `update`/`changelog` failed when the cargo workspace was a subdirectory of the git repo. Switched to `Repository::discover(cwd)`, which walks up to find `.git`.

2. **Match `[workspace.dependencies]` by `package` field** (`versioning/cargo.rs`) — version bump looked up the dependency table by key only. Renamed deps (`alias = { package = "real_name", version = ".." }`) were never found. Now matches the key *or* the `package` field.

3. **Support `version.workspace = true`** (`versioning/cargo.rs`) — members that inherit their version via `version.workspace = true` have no literal `[package] version`, which made `set_package_version` error. Now `update_version` bumps `[workspace.package].version` and skips inherited members.

All three are backward compatible — the existing oxc layout (repo-root workspace, literal versions, unrenamed deps) is unaffected. `cargo build` + `cargo clippy` clean; verified end-to-end against forked-react-compiler (`update --version 9.9.9` correctly bumps `[workspace.package].version` and all renamed publishable deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)