### PR TITLE
chore(cargo-release-oxc): exclude extraneous files from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords    = []
 categories  = []
 license     = "MIT"
 readme      = "README.md"
+include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [lints.clippy]
 all                         = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords    = []
 categories  = []
 license     = "MIT"
 readme      = "README.md"
-include = ["src/**/*", "README.md", "CHANGELOG.md"]
+include     = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [lints.clippy]
 all                         = { level = "warn", priority = -1 }


### PR DESCRIPTION
Adds explicit includes for `cargo-release-oxc` to omit 9.4 kB of files (12% of total) under `.github` and repo-level config from the published package

Files removed from the package, by directory:

| Directory | Size | Files |
|---|---|---|
| `.github/**` | 7.8 kB | 6 |
| root config (`justfile`, `release-plz.toml`, `.clippy.toml`, `.rustfmt.toml`, `.taplo.toml`, `rust-toolchain.toml`, `.gitignore`) | 1.6 kB | 7 |

Verified with publish dry run

Found with [cargo-diet](https://github.com/the-lean-crate/cargo-diet)
